### PR TITLE
Add Makefile for build and install of org.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+XDG_CONFIG_HOME ?= ~/.config
+
+.PHONY: build
+build: org.so
+
+.PHONY: install
+install: org.so
+	mkdir -p $(XDG_CONFIG_HOME)/nvim/parser/
+	cp org.so $(XDG_CONFIG_HOME)/nvim/parser/
+
+org.so: src/parser.c src/scanner.cc
+	gcc -o $@ -I./src $^ -shared -Os -lstdc++
+
+.PHONY: clean
+clean:
+	$(RM) org.so


### PR DESCRIPTION
Hi, cool project. How about a Makefile to build and install org.so? This would simplify the installation section in the README a bit and only recompile if sources have changed...