### PR TITLE
Ergonomics for Rust consumption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.19"
+tree-sitter = ">= 0.19, < 0.21"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "1.0.0"
 keywords = ["incremental", "parsing", "org"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/milisims/tree-sitter-org"
-edition = "2022"
+edition = "2021"
 license = "MIT"
 
 build = "bindings/rust/build.rs"


### PR DESCRIPTION
It looks like edition '2021' got changed to '2022' in a (license?) find-and-replace, but Rust doesn't have a 2022 language edition.

Also, we relax the tree-sitter requirements a bit to allow for the use of a 0.20.x tree-sitter dep, mirroring what the official tree-sitter Rust packages for other languages do.