### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Cargo.lock
 package-lock.json
 node_modules
 build
+/.build
 *.log
 /examples/*/
 /target/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterOrg",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [.library(name: "TreeSitterOrg", targets: ["TreeSitterOrg"])],
+    targets: [
+        .target(
+            name: "TreeSitterOrg",
+            path: ".",
+            exclude: [
+            ],
+            sources: [
+                "src/parser.c",
+                "src/scanner.c",
+            ],
+            resources: [
+                .copy("queries"),
+            ],
+            publicHeadersPath: "bindings/swift",
+            cSettings: [.headerSearchPath("src")]
+        ),
+    ]
+)

--- a/bindings/swift/TreeSitterOrg/org.h
+++ b/bindings/swift/TreeSitterOrg/org.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_ORG_H_
+#define TREE_SITTER_ORG_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_org();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_ORG_H_


### PR DESCRIPTION
Hello! This adds support for the Swift package manager (SPM), along with the necessary bindings to support it from Swift. This has been done to many other tree-sitter parser projects. The change doesn't affect the parser itself, and requires no maintenance on your part.

There are a handful of things that could potentially break the binding (like moving from a C to C++ scanner), but if that ever happens, Swift users would notice and we could just fix it. It's happened before and it generally isn't a big deal.

Happy to answer questions, if you have any!